### PR TITLE
Return null for the avatar if they don't have one set

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -69,7 +69,7 @@ class Provider extends AbstractProvider implements ProviderInterface
             'nickname' => sprintf('%s#%d', $user['username'], $user['discriminator']),
             'name' => $user['username'],
             'email' => $user['email'],
-            'avatar' => sprintf('https://discordcdn.com/avatars/%s/%s.jpg', $user['id'], $user['avatar']),
+            'avatar' => (is_null($user['avatar'])) ? null : sprintf('https://discordcdn.com/avatars/%s/%s.jpg', $user['id'], $user['avatar']),
         ]);
     }
 


### PR DESCRIPTION
Currently it returns an invalid url if the user doesn't have an avatar set. This fixes that issue and returns null for the avatar instead.
